### PR TITLE
Fixing proxyFor/proxyIn swapping

### DIFF
--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -20,10 +20,10 @@ module Hydra::PCDM
 
       indirectly_contains :member_of_collections,
                           has_member_relation: Vocab::PCDMTerms.memberOf,
-                          inserted_content_relation: RDF::Vocab::ORE.proxyIn,
+                          inserted_content_relation: RDF::Vocab::ORE.proxyFor,
                           class_name: 'ActiveFedora::Base',
                           through: 'ActiveFedora::Aggregation::Proxy',
-                          foreign_key: :container,
+                          foreign_key: :proxy_for,
                           type_validator: Validators::PCDMCollectionValidator
     end
 


### PR DESCRIPTION
Had reversed proxyFor and proxyIn, which works for Fedora, but causes problems for AF.

Keeping them the same as the other indirect containers (where proxyFor points to the remote object) works for both hydra-pcdm and AF, and is more correct usage of ORE Proxy, too.