### PR TITLE
Fixing foreign_key for ActiveFedora:Aggregation::Proxy

### DIFF
--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -23,7 +23,7 @@ module Hydra::PCDM
                           inserted_content_relation: RDF::Vocab::ORE.proxyFor,
                           class_name: 'ActiveFedora::Base',
                           through: 'ActiveFedora::Aggregation::Proxy',
-                          foreign_key: :proxy_for,
+                          foreign_key: :target,
                           type_validator: Validators::PCDMCollectionValidator
     end
 

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -524,6 +524,7 @@ describe Hydra::PCDM::Object do
     subject do
       object = described_class.new
       object.member_of_collections = [collection1, collection2]
+      object.save
       object
     end
 


### PR DESCRIPTION
When plugging the recent changes into CurationConcerns, I discovered that I had been misreading the tests and confusing a stub Proxy class (which has a proxy_for method) for AF::Aggregation::Proxy (which has target and container methods).  This PR corrects the usage to use AF::Aggregation::Proxy#target.

Sorry for the churn on this.