### PR TITLE
update gem version in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add these lines to your application's Gemfile:
 
 ```ruby
   gem 'active-fedora', '~> 9.3'
-  gem 'hydra-pcdm', '~> 0.4'
+  gem 'hydra-pcdm', '~> 0.9'
 ```
 
 And then execute:


### PR DESCRIPTION
Noticed that the REAMDE install instructions say 0.4 but the gem's current version is 0.9.

I'm wondering if a note should be included with the AF guidance info also, from https://github.com/projecthydra/active_fedora:

```
ActiveFedora is a Ruby gem for creating and managing objects in the Fedora Repository Architecture (http://fedora-commons.org). ActiveFedora is loosely based on “ActiveRecord” in Rails. Version 9.0+ works with Fedora 4 and prior versions work on Fedora 3. Version 9.2+ works with Solr 4.10. Version 10.0+ works with Fedora >= 4.5.1.
```