### PR TITLE
Update rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,19 @@ RSpec/FilePath:
 
 RSpec/InstanceVariable:
   Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/hydra/pcdm/collection_indexer_spec.rb
+    - spec/hydra/pcdm/object_indexer_spec.rb
+    - spec/hydra/pcdm/models/*
+
+RSpec/ExampleLength:
+  Exclude:
+    - spec/hydra/pcdm/models/*
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rubocop', '~> 0.37.0', require: false
-  gem 'rubocop-rspec', '~> 1.3.1', require: false
+  gem 'rubocop',       '~> 0.46.0', require: false
+  gem 'rubocop-rspec', '~> 1.9.1',  require: false
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
 end

--- a/lib/hydra/pcdm/validators/pcdm_object_validator.rb
+++ b/lib/hydra/pcdm/validators/pcdm_object_validator.rb
@@ -1,9 +1,8 @@
 module Hydra::PCDM::Validators
   class PCDMObjectValidator
     def self.validate!(_association, record)
-      unless record.try(:pcdm_object?)
-        raise ActiveFedora::AssociationTypeMismatch, "#{record} is not a PCDM object."
-      end
+      raise ActiveFedora::AssociationTypeMismatch, "#{record} is not a PCDM object." unless
+        record.try(:pcdm_object?)
     end
   end
 end

--- a/lib/hydra/pcdm/validators/pcdm_validator.rb
+++ b/lib/hydra/pcdm/validators/pcdm_validator.rb
@@ -1,9 +1,8 @@
 module Hydra::PCDM::Validators
   class PCDMValidator
     def self.validate!(_reflection, record)
-      if !record.try(:pcdm_object?) && !record.try(:pcdm_collection?)
-        raise ActiveFedora::AssociationTypeMismatch, "#{record} is not a PCDM object or collection."
-      end
+      raise ActiveFedora::AssociationTypeMismatch, "#{record} is not a PCDM object or collection." if
+        !record.try(:pcdm_object?) && !record.try(:pcdm_collection?)
     end
   end
 end

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -495,12 +495,12 @@ describe Hydra::PCDM::Collection do
   end
 
   describe '#ordered_collection_ids' do
+    subject      { object.ordered_collection_ids }
     let(:child1) { described_class.new(id: '1') }
     let(:child2) { described_class.new(id: '2') }
     let(:object) { described_class.new }
-    before { object.ordered_members = [child1, child2] }
 
-    subject { object.ordered_collection_ids }
+    before { object.ordered_members = [child1, child2] }
 
     it { is_expected.to eq %w(1 2) }
   end

--- a/spec/hydra/pcdm/models/object_spec.rb
+++ b/spec/hydra/pcdm/models/object_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Hydra::PCDM::Object do
   describe '#object_ids' do
+    subject      { object.ordered_object_ids }
     let(:child1) { described_class.new(id: '1') }
     let(:child2) { described_class.new(id: '2') }
     let(:object) { described_class.new }
@@ -9,8 +10,6 @@ describe Hydra::PCDM::Object do
       object.ordered_members << child1
       object.ordered_members << child2
     end
-
-    subject { object.ordered_object_ids }
 
     it { is_expected.to eq %w(1 2) }
   end
@@ -147,8 +146,8 @@ describe Hydra::PCDM::Object do
   end
 
   describe 'in_objects' do
+    subject      { object.in_objects }
     let(:object) { described_class.create }
-    subject { object.in_objects }
     let(:collection) { Hydra::PCDM::Collection.new }
     let(:parent_object) { described_class.new }
     context 'using ordered_members' do
@@ -317,15 +316,15 @@ describe Hydra::PCDM::Object do
           expect { @af_base_object.related_objects << @object101 }.to raise_error(NoMethodError)
         end
 
-        it 'NOT accept Hydra::PCDM::Files as parent object' do
+        it 'NOT access Hydra::PCDM::Files as parent object' do
           expect { @file101.related_objects }.to raise_error(NoMethodError)
         end
 
-        it 'NOT accept non-PCDM objects as parent object' do
+        it 'NOT access non-PCDM objects as parent object' do
           expect { @non_pcdm_object.related_objects }.to raise_error(NoMethodError)
         end
 
-        it 'NOT accept AF::Base objects as parent object' do
+        it 'NOT access AF::Base objects as parent object' do
           expect { @af_base_object.related_objects }.to raise_error(NoMethodError)
         end
       end
@@ -518,15 +517,15 @@ describe Hydra::PCDM::Object do
   end
 
   describe 'membership in collections' do
-    let(:collection1) { Hydra::PCDM::Collection.create }
-    let(:collection2) { Hydra::PCDM::Collection.create }
-
     subject do
       object = described_class.new
       object.member_of_collections = [collection1, collection2]
       object.save
       object
     end
+
+    let(:collection1) { Hydra::PCDM::Collection.create }
+    let(:collection2) { Hydra::PCDM::Collection.create }
 
     describe '#member_of_collections' do
       it 'contains collections the object is a member of' do

--- a/spec/hydra/pcdm/services/file/get_mime_type_spec.rb
+++ b/spec/hydra/pcdm/services/file/get_mime_type_spec.rb
@@ -9,14 +9,16 @@ describe Hydra::PCDM::GetMimeTypeForFile do
   end
 
   context 'with a standard file type' do
+    subject    { described_class.call(path) }
     let(:path) { '/path/file.jpg' }
-    subject { described_class.call(path) }
+
     it { is_expected.to eql 'image/jpeg' }
   end
 
   context 'with an unknown file type' do
+    subject    { described_class.call(path) }
     let(:path) { '/path/file.jkl' }
-    subject { described_class.call(path) }
+
     it { is_expected.to eql 'application/octet-stream' }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,11 @@ require 'simplecov'
 require 'coveralls'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ])
-SimpleCov.start do
-  add_filter '/spec'
-end
+  [SimpleCov::Formatter::HTMLFormatter,
+   Coveralls::SimpleCov::Formatter]
+)
+
+SimpleCov.start { add_filter '/spec' }
 
 require 'bundler/setup'
 Bundler.setup


### PR DESCRIPTION
Updates the RSpec version to work with the latest Rake. To do this, I had to update `rubocop-rspec` and fix various style issues to align with the latest guidelines.

A few rules are excluded (see: `.rubocop.yml`).